### PR TITLE
useAppSelector and useAppDispatch hooks

### DIFF
--- a/src/modules/auth/pages/LoginPage.tsx
+++ b/src/modules/auth/pages/LoginPage.tsx
@@ -1,7 +1,6 @@
-import { useDispatch } from 'react-redux';
 import { useLocation, useNavigate } from 'react-router-dom';
-import { AppDispatch } from '../../../store/store';
 import { login } from '../../../store/slices/auth';
+import { useAppDispatch } from '../../../store/hooks';
 
 
 const LoginPage = () => {
@@ -11,7 +10,7 @@ const LoginPage = () => {
   const searchParams = new URLSearchParams(location.search);
   const origin = searchParams.get('origin');
 
-  const dispatch = useDispatch<AppDispatch>();
+  const dispatch = useAppDispatch();
 
   const handleLogin = () => {
     const userPayload: IUser = { id: "1", name: 'Djamel', email: "email@gmail.com", phoneNumber: '514-944-3147', birthday: '02-07-1992' };

--- a/src/shared/components/layouts/ProtectedLayout.tsx
+++ b/src/shared/components/layouts/ProtectedLayout.tsx
@@ -1,10 +1,8 @@
-import { useSelector } from 'react-redux';
 import { Navigate, Outlet, useLocation } from 'react-router-dom';
-import { RootState } from '../../../store/store';
-
+import { useAppSelector } from '../../../store/hooks';
 
 const ProtectedLayout = () => {
-  const { isAuthenticated } = useSelector((state: RootState) => state.auth);
+  const { isAuthenticated } = useAppSelector((state) => state.auth);
   const { pathname } = useLocation();
   return (
     isAuthenticated ? <Outlet /> : <Navigate to={`/login?origin=${pathname}`} replace />

--- a/src/shared/components/layouts/helpers/MainNav/index.tsx
+++ b/src/shared/components/layouts/helpers/MainNav/index.tsx
@@ -1,16 +1,15 @@
 import { NavLink } from 'react-router-dom';
 import styles from './main-nav.module.css';
 import ProtectedLink from '../../../protected-link';
-import { useDispatch, useSelector } from 'react-redux';
-import { AppDispatch, RootState } from '../../../../../store/store';
 import { logout } from '../../../../../store/slices/auth';
+import { useAppDispatch, useAppSelector } from '../../../../../store/hooks';
 
 const MainNav = () => {
-  const dispatch = useDispatch<AppDispatch>();
+  const dispatch = useAppDispatch();
   const handleLogout = () => {
     dispatch(logout());
   };
-  const { isAuthenticated } = useSelector((state: RootState) => state.auth);
+  const { isAuthenticated } = useAppSelector((state) => state.auth);
   return (
     <nav className={styles.nav}>
       <p>AppLayout NAV</p>

--- a/src/shared/components/protected-link/index.tsx
+++ b/src/shared/components/protected-link/index.tsx
@@ -1,7 +1,6 @@
 import { ReactNode } from 'react';
-import { useSelector } from 'react-redux';
 import { Link, type LinkProps, NavLink, type NavLinkProps } from 'react-router-dom';
-import { RootState } from '../../../store/store';
+import { useAppSelector } from '../../../store/hooks';
 
 type MainProps = {
   inNav?: boolean,
@@ -11,7 +10,7 @@ type MainProps = {
 type Props = (MainProps & NavLinkProps) | (MainProps & NavLinkProps)
 
 const ProtectedLink: React.FC<Props> = ({ children, inNav = false, to, ...rest }) => {
-   const { isAuthenticated } = useSelector((state: RootState) => state.auth);
+   const { isAuthenticated } = useAppSelector((state) => state.auth);
   if (!isAuthenticated) return null;
   if (inNav) {
     return (

--- a/src/shared/components/protected-route/index.tsx
+++ b/src/shared/components/protected-route/index.tsx
@@ -1,14 +1,13 @@
 import { ReactNode } from 'react';
-import { useSelector } from 'react-redux';
 import { Navigate, useLocation } from 'react-router-dom';
-import { RootState } from '../../../store/store';
+import { useAppSelector } from '../../../store/hooks';
 
 type Props = {
   children: ReactNode,
 }
 
 const ProtectedRoute = ({ children }: Props) => {
-   const { isAuthenticated } = useSelector((state: RootState) => state.auth);
+  const { isAuthenticated } = useAppSelector((state) => state.auth);
   const { pathname } = useLocation();
   return (
     isAuthenticated ? children : <Navigate to={`/login?origin=${pathname}`} replace />

--- a/src/store/hooks.ts
+++ b/src/store/hooks.ts
@@ -1,0 +1,5 @@
+import { useDispatch, useSelector } from 'react-redux';
+import { AppDispatch, RootState } from './store';
+
+export const useAppSelector = useSelector.withTypes<RootState>();
+export const useAppDispatch = useDispatch.withTypes<AppDispatch>();


### PR DESCRIPTION
## Description

In this PR i created `useAppSelector` and `useAppDispatch` hooks and used them in order to simplify and improve the  code.

Le but est d’éviter de mentionner les types `RootState` et `AppDispatch” chaque fois que nous voulons utiliser useSelector et useDispatch, donc nous avons une version personnalisée de ces deux hooks.